### PR TITLE
Removed height requirement of parent widget

### DIFF
--- a/lib/accordion.dart
+++ b/lib/accordion.dart
@@ -204,6 +204,8 @@ class Accordion extends StatelessWidget with CommonParams {
 
     return Scrollbar(
       child: ListView(
+        shrinkWrap: true,
+        physics: ClampingScrollPhysics(),
         controller: listCtrl.controller,
         padding: EdgeInsets.only(
           top: paddingListTop,


### PR DESCRIPTION
~~you must wrap the nested Accordion with something like Container and give that wrapper a specific height~~

Parent height is not needed.