### PR TITLE
Give each instance of Accordion its own ListController

### DIFF
--- a/lib/accordion.dart
+++ b/lib/accordion.dart
@@ -124,7 +124,9 @@ class Accordion extends StatelessWidget with CommonParams {
     SectionHapticFeedback? sectionOpeningHapticFeedback,
     SectionHapticFeedback? sectionClosingHapticFeedback,
     bool? openAndCloseAnimation,
+    String? accordionId,
   }) : super(key: key) {
+    final listCtrl = Get.put(ListController(), tag: hashCode.toString());
     listCtrl.initialOpeningSequenceDelay = initialOpeningSequenceDelay ?? 0;
     listCtrl.maxOpenSections = maxOpenSections ?? 1;
 
@@ -160,10 +162,12 @@ class Accordion extends StatelessWidget with CommonParams {
     this.sectionClosingHapticFeedback =
         sectionClosingHapticFeedback ?? SectionHapticFeedback.none;
     sectionAnimation = openAndCloseAnimation ?? true;
+    this.accordionId = hashCode.toString();
   }
 
   @override
   build(context) {
+    final listCtrl = Get.put(ListController(), tag: hashCode.toString());
     return ListView.builder(
       itemCount: children.length,
       controller: listCtrl.controller,
@@ -228,6 +232,7 @@ class Accordion extends StatelessWidget with CommonParams {
                 sectionOpeningHapticFeedback,
             sectionClosingHapticFeedback: child.sectionClosingHapticFeedback ??
                 sectionClosingHapticFeedback,
+            accordionId: accordionId,
           ),
         );
       },

--- a/lib/accordion_section.dart
+++ b/lib/accordion_section.dart
@@ -37,7 +37,6 @@ class AccordionSection extends StatelessWidget with CommonParams {
   final SectionController sectionCtrl = SectionController();
   late final UniqueKey uniqueKey;
   late final int index;
-  final listCtrl = Get.put(ListController());
   final bool isOpen;
 
   /// The text to be displayed in the header
@@ -70,7 +69,9 @@ class AccordionSection extends StatelessWidget with CommonParams {
     ScrollIntoViewOfItems? scrollIntoViewOfItems,
     SectionHapticFeedback? sectionOpeningHapticFeedback,
     SectionHapticFeedback? sectionClosingHapticFeedback,
+    String? accordionId,
   }) : super(key: key) {
+    final listCtrl = Get.put(ListController(), tag: accordionId);
     uniqueKey = listCtrl.keys.elementAt(index);
     sectionCtrl.isSectionOpen.value = listCtrl.openSections.contains(uniqueKey);
 
@@ -94,6 +95,7 @@ class AccordionSection extends StatelessWidget with CommonParams {
         scrollIntoViewOfItems ?? ScrollIntoViewOfItems.fast;
     this.sectionOpeningHapticFeedback = sectionOpeningHapticFeedback;
     this.sectionClosingHapticFeedback = sectionClosingHapticFeedback;
+    this.accordionId = accordionId;
 
     listCtrl.controllerIsOpen.stream.asBroadcastStream().listen((data) {
       sectionCtrl.isSectionOpen.value = listCtrl.openSections.contains(key);
@@ -108,6 +110,7 @@ class AccordionSection extends StatelessWidget with CommonParams {
 
   /// getter indication the open or closed status of this section
   get _isOpen {
+    final listCtrl = Get.put(ListController(), tag: accordionId);
     final open = sectionCtrl.isSectionOpen.value;
 
     Timer(
@@ -164,6 +167,7 @@ class AccordionSection extends StatelessWidget with CommonParams {
         children: [
           InkWell(
             onTap: () {
+              final listCtrl = Get.put(ListController(), tag: accordionId);
               listCtrl.updateSections(uniqueKey);
               _playHapticFeedback(_isOpen);
 

--- a/lib/controllers.dart
+++ b/lib/controllers.dart
@@ -45,6 +45,7 @@ mixin CommonParams {
   late final ScrollIntoViewOfItems? scrollIntoViewOfItems;
   late final SectionHapticFeedback? sectionOpeningHapticFeedback;
   late final SectionHapticFeedback? sectionClosingHapticFeedback;
+  late final String? accordionId;
 }
 
 /// Controller for `Accordion` widget


### PR DESCRIPTION
## What is the pre-existing problem this Pull Request is trying to solve?  
Currently, it's not possible to have two `Accordion`s in the widget tree without causing errors and unwanted behaviour (e.g. two `Accordion`s expanding when one is clicked).
This is due to the fact multiple `Accordion`s use the same `ListController` instance stored by GetX.

The problem was originally raised in the following issue: https://github.com/GotJimmy/accordion/issues/20

## This PR introduces the following changes  
- Each `Accordion` instance now has its own `ListController` instance in GetX, tagged with the `Accordion`s hashCode
- Allow `Accordion` hashCode to be passed into its child `AccordionSection`s