### PR TITLE
Added left and right icons for the open state of a section, and a headerOpen parameter for more flexibility.

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -44,10 +44,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -118,10 +118,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
@@ -155,18 +155,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -187,10 +187,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
@@ -203,10 +203,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.3.0"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=3.0.0"

--- a/lib/accordion.dart
+++ b/lib/accordion.dart
@@ -62,7 +62,9 @@ class Accordion extends StatelessWidget with CommonParams {
     double? headerBorderWidth,
     double? headerBorderRadius,
     Widget? leftIcon,
+    Widget? leftIconOpen,
     Widget? rightIcon,
+    Widget? rightIconOpen,
     Widget? header,
     this.flipLeftIconIfOpen = false,
     this.flipRightIconIfOpen = true,
@@ -109,7 +111,9 @@ class Accordion extends StatelessWidget with CommonParams {
     this.headerBorderWidth = headerBorderWidth;
     this.headerBorderRadius = headerBorderRadius;
     this.leftIcon = leftIcon;
+    this.leftIconOpen = leftIconOpen;
     this.rightIcon = rightIcon;
+    this.rightIconOpen = rightIconOpen;
     SectionController.flipLeftIconIfOpen = flipLeftIconIfOpen!;
     SectionController.flipRightIconIfOpen = flipRightIconIfOpen!;
     this.contentBackgroundColor = contentBackgroundColor;
@@ -169,7 +173,7 @@ class Accordion extends StatelessWidget with CommonParams {
             header: child.header,
             headerOpen: child.headerOpen,
             leftIcon: child.leftIcon ?? leftIcon,
-            leftIconOpen: child.leftIconOpen,
+            leftIconOpen: child.leftIconOpen ?? leftIconOpen,
             rightIcon: child.rightIcon ??
                 rightIcon ??
                 const Icon(
@@ -177,7 +181,7 @@ class Accordion extends StatelessWidget with CommonParams {
                   color: Colors.white60,
                   size: 20,
                 ),
-            rightIconOpen: child.rightIconOpen,
+            rightIconOpen: child.rightIconOpen ?? rightIconOpen,
             paddingBetweenClosedSections: child.paddingBetweenClosedSections ?? paddingBetweenClosedSections,
             paddingBetweenOpenSections: child.paddingBetweenOpenSections ?? paddingBetweenOpenSections,
             content: child.content,

--- a/lib/accordion.dart
+++ b/lib/accordion.dart
@@ -96,16 +96,14 @@ class Accordion extends StatelessWidget with CommonParams {
 
     int index = 0;
     for (var child in children) {
-      if (child.isOpen &&
-          listCtrl.openSections.length < listCtrl.maxOpenSections) {
+      if (child.isOpen && listCtrl.openSections.length < listCtrl.maxOpenSections) {
         listCtrl.openSections.add(listCtrl.keys.elementAt(index));
       }
       index++;
     }
 
     this.headerBackgroundColor = headerBackgroundColor;
-    this.headerBackgroundColorOpened =
-        headerBackgroundColorOpened ?? headerBackgroundColor;
+    this.headerBackgroundColorOpened = headerBackgroundColorOpened ?? headerBackgroundColor;
     this.headerBorderColor = headerBorderColor;
     this.headerBorderColorOpened = headerBorderColorOpened ?? headerBorderColor;
     this.headerBorderWidth = headerBorderWidth;
@@ -124,10 +122,8 @@ class Accordion extends StatelessWidget with CommonParams {
     this.paddingBetweenOpenSections = paddingBetweenOpenSections;
     this.paddingBetweenClosedSections = paddingBetweenClosedSections;
     this.scrollIntoViewOfItems = scrollIntoViewOfItems;
-    this.sectionOpeningHapticFeedback =
-        sectionOpeningHapticFeedback ?? SectionHapticFeedback.none;
-    this.sectionClosingHapticFeedback =
-        sectionClosingHapticFeedback ?? SectionHapticFeedback.none;
+    this.sectionOpeningHapticFeedback = sectionOpeningHapticFeedback ?? SectionHapticFeedback.none;
+    this.sectionClosingHapticFeedback = sectionClosingHapticFeedback ?? SectionHapticFeedback.none;
     sectionAnimation = openAndCloseAnimation ?? true;
     sectionScaleAnimation = scaleWhenAnimating ?? true;
     this.accordionId = hashCode.toString();
@@ -141,9 +137,7 @@ class Accordion extends StatelessWidget with CommonParams {
       itemCount: children.length,
       controller: listCtrl.controller,
       shrinkWrap: true,
-      physics: disableScrolling
-          ? const NeverScrollableScrollPhysics()
-          : const AlwaysScrollableScrollPhysics(),
+      physics: disableScrolling ? const NeverScrollableScrollPhysics() : const AlwaysScrollableScrollPhysics(),
       padding: EdgeInsets.only(
         top: paddingListTop,
         bottom: paddingListBottom,
@@ -164,21 +158,18 @@ class Accordion extends StatelessWidget with CommonParams {
             index: index,
             isOpen: child.isOpen,
             scrollIntoViewOfItems: scrollIntoViewOfItems,
-            headerBackgroundColor:
-                child.headerBackgroundColor ?? headerBackgroundColor,
-            headerBackgroundColorOpened: child.headerBackgroundColorOpened ??
-                headerBackgroundColorOpened ??
-                headerBackgroundColor,
+            headerBackgroundColor: child.headerBackgroundColor ?? headerBackgroundColor,
+            headerBackgroundColorOpened:
+                child.headerBackgroundColorOpened ?? headerBackgroundColorOpened ?? headerBackgroundColor,
             headerBorderColor: child.headerBorderColor ?? headerBorderColor,
-            headerBorderColorOpened: child.headerBorderColorOpened ??
-                headerBorderColorOpened ??
-                headerBorderColor,
+            headerBorderColorOpened: child.headerBorderColorOpened ?? headerBorderColorOpened ?? headerBorderColor,
             headerBorderWidth: child.headerBorderWidth ?? headerBorderWidth,
             headerBorderRadius: child.headerBorderRadius ?? headerBorderRadius,
             headerPadding: child.headerPadding ?? headerPadding,
             header: child.header,
             headerOpen: child.headerOpen,
             leftIcon: child.leftIcon ?? leftIcon,
+            leftIconOpen: child.leftIconOpen,
             rightIcon: child.rightIcon ??
                 rightIcon ??
                 const Icon(
@@ -187,25 +178,17 @@ class Accordion extends StatelessWidget with CommonParams {
                   size: 20,
                 ),
             rightIconOpen: child.rightIconOpen,
-            paddingBetweenClosedSections: child.paddingBetweenClosedSections ??
-                paddingBetweenClosedSections,
-            paddingBetweenOpenSections:
-                child.paddingBetweenOpenSections ?? paddingBetweenOpenSections,
+            paddingBetweenClosedSections: child.paddingBetweenClosedSections ?? paddingBetweenClosedSections,
+            paddingBetweenOpenSections: child.paddingBetweenOpenSections ?? paddingBetweenOpenSections,
             content: child.content,
-            contentBackgroundColor:
-                child.contentBackgroundColor ?? contentBackgroundColor,
+            contentBackgroundColor: child.contentBackgroundColor ?? contentBackgroundColor,
             contentBorderColor: child.contentBorderColor ?? contentBorderColor,
             contentBorderWidth: child.contentBorderWidth ?? contentBorderWidth,
-            contentBorderRadius:
-                child.contentBorderRadius ?? contentBorderRadius,
-            contentHorizontalPadding:
-                child.contentHorizontalPadding ?? contentHorizontalPadding,
-            contentVerticalPadding:
-                child.contentVerticalPadding ?? contentVerticalPadding,
-            sectionOpeningHapticFeedback: child.sectionOpeningHapticFeedback ??
-                sectionOpeningHapticFeedback,
-            sectionClosingHapticFeedback: child.sectionClosingHapticFeedback ??
-                sectionClosingHapticFeedback,
+            contentBorderRadius: child.contentBorderRadius ?? contentBorderRadius,
+            contentHorizontalPadding: child.contentHorizontalPadding ?? contentHorizontalPadding,
+            contentVerticalPadding: child.contentVerticalPadding ?? contentVerticalPadding,
+            sectionOpeningHapticFeedback: child.sectionOpeningHapticFeedback ?? sectionOpeningHapticFeedback,
+            sectionClosingHapticFeedback: child.sectionClosingHapticFeedback ?? sectionClosingHapticFeedback,
             accordionId: accordionId,
             onOpenSection: child.onOpenSection,
             onCloseSection: child.onCloseSection,

--- a/lib/accordion.dart
+++ b/lib/accordion.dart
@@ -177,6 +177,7 @@ class Accordion extends StatelessWidget with CommonParams {
             headerBorderRadius: child.headerBorderRadius ?? headerBorderRadius,
             headerPadding: child.headerPadding ?? headerPadding,
             header: child.header,
+            headerOpen: child.headerOpen,
             leftIcon: child.leftIcon ?? leftIcon,
             rightIcon: child.rightIcon ??
                 rightIcon ??
@@ -185,6 +186,7 @@ class Accordion extends StatelessWidget with CommonParams {
                   color: Colors.white60,
                   size: 20,
                 ),
+            rightIconOpen: child.rightIconOpen,
             paddingBetweenClosedSections: child.paddingBetweenClosedSections ??
                 paddingBetweenClosedSections,
             paddingBetweenOpenSections:

--- a/lib/accordion_section.dart
+++ b/lib/accordion_section.dart
@@ -88,11 +88,9 @@ class AccordionSection extends StatelessWidget with CommonParams {
     sectionCtrl.isSectionOpen.value = listCtrl.openSections.contains(uniqueKey);
 
     this.headerBackgroundColor = headerBackgroundColor;
-    this.headerBackgroundColorOpened =
-        headerBackgroundColorOpened ?? headerBackgroundColor;
+    this.headerBackgroundColorOpened = headerBackgroundColorOpened ?? headerBackgroundColor;
     this.headerBorderColor = headerBorderColor ?? headerBackgroundColor;
-    this.headerBorderColorOpened =
-        headerBorderColorOpened ?? headerBackgroundColorOpened;
+    this.headerBorderColorOpened = headerBorderColorOpened ?? headerBackgroundColorOpened;
     this.headerBorderWidth = headerBorderWidth;
     this.headerBorderRadius = headerBorderRadius;
     this.headerPadding = headerPadding;
@@ -108,8 +106,7 @@ class AccordionSection extends StatelessWidget with CommonParams {
     this.contentVerticalPadding = contentVerticalPadding;
     this.paddingBetweenOpenSections = paddingBetweenOpenSections;
     this.paddingBetweenClosedSections = paddingBetweenClosedSections;
-    this.scrollIntoViewOfItems =
-        scrollIntoViewOfItems ?? ScrollIntoViewOfItems.fast;
+    this.scrollIntoViewOfItems = scrollIntoViewOfItems ?? ScrollIntoViewOfItems.fast;
     this.sectionOpeningHapticFeedback = sectionOpeningHapticFeedback;
     this.sectionClosingHapticFeedback = sectionClosingHapticFeedback;
     this.accordionId = accordionId;
@@ -122,14 +119,12 @@ class AccordionSection extends StatelessWidget with CommonParams {
   /// getter to flip the widget vertically (Icon by default)
   /// on the left of this section header to visually indicate
   /// if this section is open or closed
-  get _flipQuarterTurnsLeft =>
-      SectionController.flipLeftIconIfOpen && _isOpen ? 2 : 0;
+  get _flipQuarterTurnsLeft => SectionController.flipLeftIconIfOpen && _isOpen ? 2 : 0;
 
   /// getter to flip the widget vertically (Icon by default)
   /// on the right of this section header to visually indicate
   /// if this section is open or closed
-  get _flipQuarterTurnsRight =>
-      SectionController.flipRightIconIfOpen && _isOpen ? 2 : 0;
+  get _flipQuarterTurnsRight => SectionController.flipRightIconIfOpen && _isOpen ? 2 : 0;
 
   /// getter indication the open or closed status of this section
   get _isOpen {
@@ -137,14 +132,10 @@ class AccordionSection extends StatelessWidget with CommonParams {
     final open = sectionCtrl.isSectionOpen.value;
 
     Timer(
-      sectionCtrl.firstRun
-          ? (listCtrl.initialOpeningSequenceDelay + min(index * 200, 1000))
-              .milliseconds
-          : 0.seconds,
+      sectionCtrl.firstRun ? (listCtrl.initialOpeningSequenceDelay + min(index * 200, 1000)).milliseconds : 0.seconds,
       () {
         if (Accordion.sectionAnimation) {
-          sectionCtrl.controller
-              .fling(velocity: open ? 1 : -1, springDescription: springFast);
+          sectionCtrl.controller.fling(velocity: open ? 1 : -1, springDescription: springFast);
         } else {
           sectionCtrl.controller.value = open ? 1 : 0;
         }
@@ -157,8 +148,7 @@ class AccordionSection extends StatelessWidget with CommonParams {
 
   /// play haptic feedback when opening/closing sections
   _playHapticFeedback(bool opening) {
-    final feedback =
-        opening ? sectionOpeningHapticFeedback : sectionClosingHapticFeedback;
+    final feedback = opening ? sectionOpeningHapticFeedback : sectionClosingHapticFeedback;
 
     switch (feedback) {
       case SectionHapticFeedback.light:
@@ -208,20 +198,14 @@ class AccordionSection extends StatelessWidget with CommonParams {
                 listCtrl.updateSections(uniqueKey);
                 _playHapticFeedback(_isOpen);
 
-                if (_isOpen &&
-                    scrollIntoViewOfItems != ScrollIntoViewOfItems.none &&
-                    listCtrl.controller.hasClients) {
+                if (!_isOpen && scrollIntoViewOfItems != ScrollIntoViewOfItems.none && listCtrl.controller.hasClients) {
                   Timer(
                     250.milliseconds,
                     () {
                       listCtrl.controller.cancelAllHighlights();
                       listCtrl.controller.scrollToIndex(index,
                           preferPosition: AutoScrollPosition.middle,
-                          duration: (scrollIntoViewOfItems ==
-                                      ScrollIntoViewOfItems.fast
-                                  ? .5
-                                  : 1)
-                              .seconds);
+                          duration: (scrollIntoViewOfItems == ScrollIntoViewOfItems.fast ? .5 : 1).seconds);
                     },
                   );
                 }
@@ -233,30 +217,21 @@ class AccordionSection extends StatelessWidget with CommonParams {
                 }
               },
               child: AnimatedContainer(
-                duration: Accordion.sectionAnimation
-                    ? 750.milliseconds
-                    : 0.milliseconds,
+                duration: Accordion.sectionAnimation ? 750.milliseconds : 0.milliseconds,
                 curve: Curves.easeOut,
                 alignment: Alignment.center,
                 padding: headerPadding,
                 decoration: BoxDecoration(
-                  color: (_isOpen
-                          ? headerBackgroundColorOpened
-                          : headerBackgroundColor) ??
-                      Theme.of(context).primaryColor,
+                  color:
+                      (_isOpen ? headerBackgroundColorOpened : headerBackgroundColor) ?? Theme.of(context).primaryColor,
                   borderRadius: BorderRadius.vertical(
                     top: Radius.circular(borderRadius),
                     bottom: Radius.circular(_isOpen ? 0 : borderRadius),
                   ),
                   border: Border.all(
-                    color: (_isOpen
-                            ? headerBorderColorOpened
-                            : headerBorderColor) ??
-                        Theme.of(context).primaryColor,
+                    color: (_isOpen ? headerBorderColorOpened : headerBorderColor) ?? Theme.of(context).primaryColor,
                     width: (headerBorderWidth ?? 0),
-                    style: (headerBorderWidth ?? 0) <= 0
-                        ? BorderStyle.none
-                        : BorderStyle.solid,
+                    style: (headerBorderWidth ?? 0) <= 0 ? BorderStyle.none : BorderStyle.solid,
                   ),
                 ),
                 child: Row(
@@ -269,8 +244,7 @@ class AccordionSection extends StatelessWidget with CommonParams {
                     Expanded(
                       flex: 10,
                       child: Padding(
-                        padding: EdgeInsets.symmetric(
-                            horizontal: leftIcon == null ? 0 : 15),
+                        padding: EdgeInsets.symmetric(horizontal: leftIcon == null ? 0 : 15),
                         child: _isOpen ? headerOpen ?? header : header,
                       ),
                     ),
@@ -290,23 +264,17 @@ class AccordionSection extends StatelessWidget with CommonParams {
           ),
           Padding(
             padding: EdgeInsets.only(
-                bottom: _isOpen
-                    ? paddingBetweenOpenSections ?? 10
-                    : paddingBetweenClosedSections ?? 10),
+                bottom: _isOpen ? paddingBetweenOpenSections ?? 10 : paddingBetweenClosedSections ?? 10),
             child: SizeTransition(
               sizeFactor: sectionCtrl.controller,
               child: ScaleTransition(
-                scale: Accordion.sectionScaleAnimation
-                    ? sectionCtrl.controller
-                    : const AlwaysStoppedAnimation(1.0),
+                scale: Accordion.sectionScaleAnimation ? sectionCtrl.controller : const AlwaysStoppedAnimation(1.0),
                 child: Center(
                   child: Container(
                     clipBehavior: Clip.antiAlias,
                     decoration: BoxDecoration(
-                      color:
-                          contentBorderColor ?? Theme.of(context).primaryColor,
-                      borderRadius: BorderRadius.vertical(
-                          bottom: Radius.circular(contentBorderRadius)),
+                      color: contentBorderColor ?? Theme.of(context).primaryColor,
+                      borderRadius: BorderRadius.vertical(bottom: Radius.circular(contentBorderRadius)),
                     ),
                     child: Padding(
                       padding: EdgeInsets.fromLTRB(
@@ -319,16 +287,12 @@ class AccordionSection extends StatelessWidget with CommonParams {
                         clipBehavior: Clip.antiAlias,
                         decoration: BoxDecoration(
                             color: Colors.white,
-                            borderRadius: BorderRadius.vertical(
-                                bottom: Radius.circular(
-                                    contentBorderRadius / 1.02))),
+                            borderRadius: BorderRadius.vertical(bottom: Radius.circular(contentBorderRadius / 1.02))),
                         child: Container(
                           clipBehavior: Clip.antiAlias,
                           decoration: BoxDecoration(
                               color: contentBackgroundColor,
-                              borderRadius: BorderRadius.vertical(
-                                  bottom: Radius.circular(
-                                      contentBorderRadius / 1.02))),
+                              borderRadius: BorderRadius.vertical(bottom: Radius.circular(contentBorderRadius / 1.02))),
                           child: Padding(
                             padding: EdgeInsets.symmetric(
                               horizontal: contentHorizontalPadding ?? 10,

--- a/lib/accordion_section.dart
+++ b/lib/accordion_section.dart
@@ -66,6 +66,7 @@ class AccordionSection extends StatelessWidget with CommonParams {
     double? headerBorderRadius,
     EdgeInsets? headerPadding,
     Widget? leftIcon,
+    Widget? leftIconOpen,
     Widget? rightIcon,
     Widget? rightIconOpen,
     Color? contentBackgroundColor,
@@ -96,6 +97,7 @@ class AccordionSection extends StatelessWidget with CommonParams {
     this.headerPadding = headerPadding;
     this.headerOpen = headerOpen;
     this.leftIcon = leftIcon;
+    this.leftIconOpen = leftIconOpen;
     this.rightIcon = rightIcon;
     this.rightIconOpen = rightIconOpen;
     this.contentBackgroundColor = contentBackgroundColor;
@@ -237,10 +239,14 @@ class AccordionSection extends StatelessWidget with CommonParams {
                 child: Row(
                   children: [
                     if (leftIcon != null)
-                      RotatedBox(
-                        quarterTurns: _flipQuarterTurnsLeft,
-                        child: leftIcon!,
-                      ),
+                      (leftIconOpen != null)
+                          ? _isOpen
+                              ? leftIconOpen!
+                              : leftIcon!
+                          : RotatedBox(
+                              quarterTurns: _flipQuarterTurnsLeft,
+                              child: leftIcon!,
+                            ),
                     Expanded(
                       flex: 10,
                       child: Padding(

--- a/lib/accordion_section.dart
+++ b/lib/accordion_section.dart
@@ -57,6 +57,7 @@ class AccordionSection extends StatelessWidget with CommonParams {
     this.isOpen = false,
     required this.header,
     required this.content,
+    Widget? headerOpen,
     Color? headerBackgroundColor,
     Color? headerBackgroundColorOpened,
     Color? headerBorderColor,
@@ -66,6 +67,7 @@ class AccordionSection extends StatelessWidget with CommonParams {
     EdgeInsets? headerPadding,
     Widget? leftIcon,
     Widget? rightIcon,
+    Widget? rightIconOpen,
     Color? contentBackgroundColor,
     Color? contentBorderColor,
     double? contentBorderWidth,
@@ -94,8 +96,10 @@ class AccordionSection extends StatelessWidget with CommonParams {
     this.headerBorderWidth = headerBorderWidth;
     this.headerBorderRadius = headerBorderRadius;
     this.headerPadding = headerPadding;
+    this.headerOpen = headerOpen;
     this.leftIcon = leftIcon;
     this.rightIcon = rightIcon;
+    this.rightIconOpen = rightIconOpen;
     this.contentBackgroundColor = contentBackgroundColor;
     this.contentBorderColor = contentBorderColor;
     this.contentBorderWidth = contentBorderWidth;
@@ -185,88 +189,102 @@ class AccordionSection extends StatelessWidget with CommonParams {
       () => Column(
         key: uniqueKey,
         children: [
-          InkWell(
-            borderRadius: BorderRadius.vertical(
-              top: Radius.circular(borderRadius),
-              bottom: Radius.circular(_isOpen ? 0 : borderRadius),
-            ),
-            onTap: () {
-              final listCtrl = Get.put(ListController(), tag: accordionId);
-
-              listCtrl.updateSections(uniqueKey);
-              _playHapticFeedback(_isOpen);
-
-              if (_isOpen &&
-                  scrollIntoViewOfItems != ScrollIntoViewOfItems.none &&
-                  listCtrl.controller.hasClients) {
-                Timer(
-                  250.milliseconds,
-                  () {
-                    listCtrl.controller.cancelAllHighlights();
-                    listCtrl.controller.scrollToIndex(index,
-                        preferPosition: AutoScrollPosition.middle,
-                        duration:
-                            (scrollIntoViewOfItems == ScrollIntoViewOfItems.fast
-                                    ? .5
-                                    : 1)
-                                .seconds);
-                  },
-                );
-              }
-
-              if (_isOpen) {
-                if (onCloseSection != null) onCloseSection!.call();
-              } else {
-                if (onOpenSection != null) onOpenSection!.call();
-              }
-            },
-            child: AnimatedContainer(
-              duration: Accordion.sectionAnimation
-                  ? 750.milliseconds
-                  : 0.milliseconds,
-              curve: Curves.easeOut,
-              alignment: Alignment.center,
-              padding: headerPadding,
-              decoration: BoxDecoration(
-                color: (_isOpen
-                        ? headerBackgroundColorOpened
-                        : headerBackgroundColor) ??
-                    Theme.of(context).primaryColor,
-                borderRadius: BorderRadius.vertical(
-                  top: Radius.circular(borderRadius),
-                  bottom: Radius.circular(_isOpen ? 0 : borderRadius),
-                ),
-                border: Border.all(
-                  color:
-                      (_isOpen ? headerBorderColorOpened : headerBorderColor) ??
-                          Theme.of(context).primaryColor,
-                  width: (headerBorderWidth ?? 0),
-                  style: (headerBorderWidth ?? 0) <= 0
-                      ? BorderStyle.none
-                      : BorderStyle.solid,
-                ),
+          Container(
+            decoration: BoxDecoration(
+              color: headerBackgroundColor ?? Theme.of(context).primaryColor,
+              borderRadius: BorderRadius.vertical(
+                top: Radius.circular(borderRadius),
+                bottom: Radius.circular(_isOpen ? 0 : borderRadius),
               ),
-              child: Row(
-                children: [
-                  if (leftIcon != null)
-                    RotatedBox(
-                      quarterTurns: _flipQuarterTurnsLeft,
-                      child: leftIcon!,
-                    ),
-                  Expanded(
-                    flex: 10,
-                    child: Padding(
-                      padding: EdgeInsets.symmetric(
-                          horizontal: leftIcon == null ? 0 : 15),
-                      child: header,
-                    ),
+            ),
+            child: InkWell(
+              borderRadius: BorderRadius.vertical(
+                top: Radius.circular(borderRadius),
+                bottom: Radius.circular(_isOpen ? 0 : borderRadius),
+              ),
+              onTap: () {
+                final listCtrl = Get.put(ListController(), tag: accordionId);
+
+                listCtrl.updateSections(uniqueKey);
+                _playHapticFeedback(_isOpen);
+
+                if (_isOpen &&
+                    scrollIntoViewOfItems != ScrollIntoViewOfItems.none &&
+                    listCtrl.controller.hasClients) {
+                  Timer(
+                    250.milliseconds,
+                    () {
+                      listCtrl.controller.cancelAllHighlights();
+                      listCtrl.controller.scrollToIndex(index,
+                          preferPosition: AutoScrollPosition.middle,
+                          duration: (scrollIntoViewOfItems ==
+                                      ScrollIntoViewOfItems.fast
+                                  ? .5
+                                  : 1)
+                              .seconds);
+                    },
+                  );
+                }
+
+                if (_isOpen) {
+                  if (onCloseSection != null) onCloseSection!.call();
+                } else {
+                  if (onOpenSection != null) onOpenSection!.call();
+                }
+              },
+              child: AnimatedContainer(
+                duration: Accordion.sectionAnimation
+                    ? 750.milliseconds
+                    : 0.milliseconds,
+                curve: Curves.easeOut,
+                alignment: Alignment.center,
+                padding: headerPadding,
+                decoration: BoxDecoration(
+                  color: (_isOpen
+                          ? headerBackgroundColorOpened
+                          : headerBackgroundColor) ??
+                      Theme.of(context).primaryColor,
+                  borderRadius: BorderRadius.vertical(
+                    top: Radius.circular(borderRadius),
+                    bottom: Radius.circular(_isOpen ? 0 : borderRadius),
                   ),
-                  if (rightIcon != null)
-                    RotatedBox(
-                      quarterTurns: _flipQuarterTurnsRight,
-                      child: rightIcon!,
+                  border: Border.all(
+                    color: (_isOpen
+                            ? headerBorderColorOpened
+                            : headerBorderColor) ??
+                        Theme.of(context).primaryColor,
+                    width: (headerBorderWidth ?? 0),
+                    style: (headerBorderWidth ?? 0) <= 0
+                        ? BorderStyle.none
+                        : BorderStyle.solid,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    if (leftIcon != null)
+                      RotatedBox(
+                        quarterTurns: _flipQuarterTurnsLeft,
+                        child: leftIcon!,
+                      ),
+                    Expanded(
+                      flex: 10,
+                      child: Padding(
+                        padding: EdgeInsets.symmetric(
+                            horizontal: leftIcon == null ? 0 : 15),
+                        child: _isOpen ? headerOpen ?? header : header,
+                      ),
                     ),
-                ],
+                    if (rightIcon != null)
+                      (rightIconOpen != null)
+                          ? _isOpen
+                              ? rightIconOpen!
+                              : rightIcon!
+                          : RotatedBox(
+                              quarterTurns: _flipQuarterTurnsRight,
+                              child: rightIcon!,
+                            )
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/controllers.dart
+++ b/lib/controllers.dart
@@ -49,7 +49,7 @@ mixin CommonParams {
   late final double? headerBorderRadius;
   late final EdgeInsets? headerPadding;
   late final Widget? headerOpen;
-  late final Widget? leftIcon, rightIcon, rightIconOpen;
+  late final Widget? leftIcon, leftIconOpen, rightIcon, rightIconOpen;
   late final Color? contentBackgroundColor;
   late final Color? contentBorderColor;
   late final double? contentBorderWidth;
@@ -69,8 +69,7 @@ class ListController extends GetxController {
   final controller = AutoScrollController(axis: Axis.vertical);
   final openSections = <UniqueKey>[];
   final keys = List<UniqueKey>.generate(10000, (index) => UniqueKey());
-  StreamController<String> controllerIsOpen =
-      StreamController<String>.broadcast();
+  StreamController<String> controllerIsOpen = StreamController<String>.broadcast();
 
   /// Maximum number of open sections at any given time.
   /// Opening a new section will close the "oldest" open section
@@ -85,9 +84,7 @@ class ListController extends GetxController {
   /// adds or removes a section key from the list of open sections
   /// and notifies sections to open or close accordingly
   void updateSections(UniqueKey key) {
-    openSections.contains(key)
-        ? openSections.remove(key)
-        : openSections.add(key);
+    openSections.contains(key) ? openSections.remove(key) : openSections.add(key);
 
     while (openSections.length > maxOpenSections) {
       openSections.removeAt(0);
@@ -105,8 +102,7 @@ class ListController extends GetxController {
 }
 
 /// Controller for `AccordionSection` widgets
-class SectionController extends GetxController
-    with GetSingleTickerProviderStateMixin {
+class SectionController extends GetxController with GetSingleTickerProviderStateMixin {
   late final controller = AnimationController(vsync: this);
   final isSectionOpen = false.obs;
   bool firstRun = true;

--- a/lib/controllers.dart
+++ b/lib/controllers.dart
@@ -48,7 +48,8 @@ mixin CommonParams {
 
   late final double? headerBorderRadius;
   late final EdgeInsets? headerPadding;
-  late final Widget? leftIcon, rightIcon;
+  late final Widget? headerOpen;
+  late final Widget? leftIcon, rightIcon, rightIconOpen;
   late final Color? contentBackgroundColor;
   late final Color? contentBorderColor;
   late final double? contentBorderWidth;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -58,10 +58,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   scroll_to_index:
     dependency: "direct main"
     description:
@@ -87,10 +87,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.3.0"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=3.0.0"


### PR DESCRIPTION
I've added `leftIconOpen` and `rightIconOpen` to both `AccordionSection` and `Accordion` to enable displaying alternative icons when a section is open.
I've also added a `headerOpen` parameter to `AccordionSection` to enable an alternative header when the section is opened. My requirement was to display a long title with an ellipsis if the section is closed, and the full title if it is opened. 
All parameters are optional, so it's a non-breaking change.
